### PR TITLE
Qualche fix per domande con codice

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -46,3 +46,12 @@ a:hover {
 #btn-quiz-reload {
     margin-top: 10px;
 }
+
+.answer-code {
+    border: 1px solid rgba(127, 127, 127, 0.7);
+    white-space: break-spaces;
+}
+
+.answer-label {
+    width: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -199,8 +199,8 @@
         // Call updateStarsCount when the page loads
         updateStarsCount();
 
-        // Execute updateStarsCount every 3 seconds
-        setInterval(updateStarsCount, 3000); // 3000 milliseconds = 3 seconds
+        // Execute updateStarsCount every 30 seconds
+        setInterval(updateStarsCount, 30000); // 30000 milliseconds = 30 seconds
     </script>
 </body>
 

--- a/js/main.js
+++ b/js/main.js
@@ -474,7 +474,10 @@ function loadElements(questions) {
         // if question has source code, then renderize it into a div
         if (questions[i]['code'] !== undefined && questions[i]['code'].length > 0) {
             var codeDiv = document.createElement('div');
-            codeDiv.innerHTML = "<pre>" + questions[i]['code'] + "</pre>";
+            var codeBlock = document.createElement('pre');
+            var codeText = document.createTextNode(questions[i]['code']);
+            codeBlock.appendChild(codeText);
+            codeDiv.appendChild(codeBlock);
             card.appendChild(codeDiv);
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -495,22 +495,16 @@ function loadElements(questions) {
 
             var lblAnswer = document.createElement('label');
             lblAnswer.classList.add('form-check-label');
+            lblAnswer.classList.add('answer-label');
             lblAnswer.htmlFor = 'answer' + i + "." + j;
 
             // if answers_have_code == 1 *in json* then let's render our answers as code in a pre block
             if (questions[i]['answers_have_code']) {
-                var description = document.createElement('textarea')
-                description.name = "taAnswerCode"
-                description.textContent = " " + answers[j];
-                description.readOnly = true;
-                description.cols = 100;
-                description.rows = 10;
-
-                // Textarea must fits into the parent
-                description.style.width = "100%";
-
+                var description = document.createElement('pre');
+                description.classList.add('answer-code');
+                description.textContent = answers[j];
             } else {
-                var description = document.createTextNode(" " + answers[j])
+                var description = document.createTextNode(" " + answers[j]);
             }
             lblAnswer.appendChild(description);
 


### PR DESCRIPTION
Questa PR include qualche fix estetici per la visualizzazione dei blocchi di codice nelle domande/risposte. Ad esempio, alcune parti di testo come `#include <...>` venivano erroneamente interpretate come tag HTML, quindi si vedeva solo `#include`.

Ho anche cambiato il refresh del conteggio delle star da 3 a 30 secondi, dopo un po' che la pagina restava aperta le richieste iniziavano a colpire il rate-limit di Github